### PR TITLE
Add square bracket check

### DIFF
--- a/src/JSON.mo
+++ b/src/JSON.mo
@@ -26,7 +26,7 @@ module JSON {
             case (#Array(v)) {
                 var s = "[";
                 for (i in v.vals()) {
-                    if (s != "") { s #= ", "; };
+                    if (s != "[") { s #= ", "; };
                     s #= show(i);
                 };
                 s # "]";


### PR DESCRIPTION
Fixes #
When using arrays the first element was prepended with an comma, like so;
`[, 5, 1, 2, 4, 5, 6]`

The edited check fixes the issue.
